### PR TITLE
Fix indentation in download component

### DIFF
--- a/facefusion/uis/components/download.py
+++ b/facefusion/uis/components/download.py
@@ -26,15 +26,15 @@ def listen() -> None:
 
 
 def update_download_providers(download_providers : List[DownloadProvider]) -> gradio.CheckboxGroup:
-        common_modules =\
-        [
-                face_classifier,
-                face_detector,
-                face_landmarker,
-                face_recognizer,
-                face_masker,
-                voice_extractor
-        ]
+	common_modules =\
+	[
+		face_classifier,
+		face_detector,
+		face_landmarker,
+		face_recognizer,
+		face_masker,
+		voice_extractor
+	]
 	available_processors = [ get_file_name(file_path) for file_path in resolve_file_paths('facefusion/processors/modules') ]
 	processor_modules = get_processors_modules(available_processors)
 


### PR DESCRIPTION
## Summary
- fix inconsistent use of tabs and spaces in `download.py`

## Testing
- `python -m tabnanny -v facefusion/uis/components/download.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `mypy --config-file mypy.ini facefusion.py install.py facefusion tests` *(fails: Duplicate module named "facefusion")*

------
https://chatgpt.com/codex/tasks/task_b_68854d90c9748329b2ddbdb2e7187143