### PR TITLE
Fix indentation issue in execution UI component

### DIFF
--- a/facefusion/uis/components/execution.py
+++ b/facefusion/uis/components/execution.py
@@ -26,14 +26,14 @@ def listen() -> None:
 
 
 def update_execution_providers(execution_providers : List[ExecutionProvider]) -> gradio.CheckboxGroup:
-        common_modules =\
-        [
-                face_classifier,
-                face_detector,
-                face_landmarker,
-                face_masker,
-                face_recognizer,
-                voice_extractor
+	common_modules =\
+	[
+		face_classifier,
+		face_detector,
+		face_landmarker,
+		face_masker,
+		face_recognizer,
+		voice_extractor
 	]
 	available_processors = [ get_file_name(file_path) for file_path in resolve_file_paths('facefusion/processors/modules') ]
 	processor_modules = get_processors_modules(available_processors)


### PR DESCRIPTION
## Summary
- ensure `facefusion.uis.components.execution` uses consistent tab indentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68854f42f9b883299edc681e5d886479